### PR TITLE
Deprecating (in words) vs:ParamHTTP's testQuery.

### DIFF
--- a/VODataService-v1.3.xsd
+++ b/VODataService-v1.3.xsd
@@ -644,10 +644,8 @@
                        it will produce a legal, non-null response.
                     </xs:documentation>
                     <xs:documentation>
-                       When the interface supports GET, then the full
-                       query URL is formed by the concatenation of the
-                       base URL (given by the accessURL) and the value
-                       given by this testQuery element.
+                       This is a legacy element; use testQueryString from
+                       vr:Interface instead.
                     </xs:documentation>
                   </xs:annotation>
                </xs:element>

--- a/VODataService.tex
+++ b/VODataService.tex
@@ -1980,10 +1980,8 @@ containers.
 
 \item[Occurrence] optional
 \item[Comment]
-                       When the interface supports GET, then the full
-                       query URL is formed by the concatenation of the
-                       base URL (given by the accessURL) and the value
-                       given by this testQuery element.
+                       This is a legacy element; use testQueryString from
+                       vr:Interface instead.
 
 
 \end{description}


### PR DESCRIPTION
In VOResource 1.1, we added testQueryString to vr:Interface; hence, the more specialised testQuery from vs:ParamHTTP is no longer necessary.