### PR TITLE
The dataSource vocabulary URL now points to the right vocabulary.

### DIFF
--- a/VODataService-v1.3.xsd
+++ b/VODataService-v1.3.xsd
@@ -6,7 +6,7 @@
            xmlns:stc="http://www.ivoa.net/xml/STC/stc-v1.30.xsd"
            xmlns:vm="http://www.ivoa.net/xml/VOMetadata/v0.1"
            elementFormDefault="unqualified" attributeFormDefault="unqualified"
-           version="1.3-wd3">
+           version="1.3-wd4">
 
    <xs:annotation>
       <xs:appinfo>
@@ -568,7 +568,7 @@
 	              	<xs:documentation>
 	              		The process that produced the data reported here,
 	              		taken from the IVOA vocabulary
-	              		http://www.ivoa.net/rdf/product-type.
+	              		http://www.ivoa.net/rdf/data-source.
 	              	</xs:documentation>
 	              	<xs:documentation>
 	              	   If nothing is given here, consumers should assume

--- a/VODataService.tex
+++ b/VODataService.tex
@@ -714,9 +714,9 @@ front.  At this point, the controlled vocabulary
 \url{http://www.ivoa.net/rdf/data-source} contains these terms:
 
 % GENERATED: !vocterms data-source
+\textsl{artificial},
 \textsl{observation},
-\textsl{theory},
-\textsl{artificial}
+\textsl{theory}
 % /GENERATED
 
 Following previous VO practice, resources giving no data source can be
@@ -733,15 +733,11 @@ equality) when sensible.
         \renewcommand*\descriptionlabel[1]{%
         \hbox to 5.5em{\emph{#1}\hfil}}\vspace{2ex}\noindent\textbf{\xmlel{vs:DataResource} Type Schema Documentation}
 
-\noindent{\small
-           A resource publishing astronomical data.
-         \par}
+\noindent{\small{}A resource publishing astronomical data.\par}
 
-\noindent{\small
-            This resource type should only be used if the resource has no
+\noindent{\small{}This resource type should only be used if the resource has no
             common underlying tabular schema (e.g., an inhomogeneous archive).
-            Use CatalogResource otherwise.
-         \par}
+            Use CatalogResource otherwise.\par}
 
 \vspace{1ex}\noindent\textbf{\xmlel{vs:DataResource} Type Schema Definition}
 
@@ -770,68 +766,54 @@ equality) when sensible.
 \begingroup\small\begin{bigdescription}\item[Element \xmlel{facility}]
 \begin{description}
 \item[Type] string with ID attribute: vr:ResourceName
-\item[Meaning]
-                     The observatory or facility used to collect the data
+\item[Meaning] The observatory or facility used to collect the data
                      contained or managed by this resource.
-
 \item[Occurrence] optional; multiple occurrences allowed.
 
 \end{description}
 \item[Element \xmlel{instrument}]
 \begin{description}
 \item[Type] string with ID attribute: vr:ResourceName
-\item[Meaning]
-                     The instrument used to collect the data contain or
+\item[Meaning] The instrument used to collect the data contain or
                      managed by a resource.
-
 \item[Occurrence] optional; multiple occurrences allowed.
 
 \end{description}
 \item[Element \xmlel{coverage}]
 \begin{description}
 \item[Type] composite: \xmlel{vs:Coverage}
-\item[Meaning]
-                     Extent of the content of the resource over space, time,
+\item[Meaning] Extent of the content of the resource over space, time,
                      and frequency.
-
 \item[Occurrence] optional
 
 \end{description}
 \item[Element \xmlel{productTypeServed}]
 \begin{description}
 \item[Type] string: \xmlel{xs:token}
-\item[Meaning]
-	              		Collections of data products (e.g., images or spectra)
+\item[Meaning] Collections of data products (e.g., images or spectra)
 	              		or services serving them define the type of products
 	              		they contain or serve here.  The strings here must
 	              		be taken from the IVOA vocabulary
 	              		\url{http://www.ivoa.net/rdf/product-type}.
-
 \item[Occurrence] optional; multiple occurrences allowed.
-\item[Comment]
-	              	   This information is intended
+\item[Comment] This information is intended
 	              		to enable global product discovery.  Hence, services
 	              		failing to define their product type(s) risk being skipped
 	              		by clients doing typed global dataset discovery.
-	              	
 
 \end{description}
 \item[Element \xmlel{dataSource}]
 \begin{description}
 \item[Type] string: \xmlel{xs:token}
-\item[Meaning]
-	              		The process that produced the data reported here,
+\item[Meaning] The process that produced the data reported here,
 	              		taken from the IVOA vocabulary
-	              		\url{http://www.ivoa.net/rdf/product-type}.
-	              	
+	              		\url{http://www.ivoa.net/rdf/data-source}.
 \item[Occurrence] optional; multiple occurrences allowed.
-\item[Comment]
-	              	   If nothing is given here, consumers should assume
+\item[Comment] If nothing is given here, consumers should assume
 	              	   'observation' as the data source.  Also, clients
 	              	   should note that more refined terms can be introduced
 	              	   at any time and should follow semantic relations
 	              	   given in the vocabulary if appropriate.
-	              	
 
 \end{description}
 
@@ -896,16 +878,12 @@ a service only publishes a single resource, use the
         \renewcommand*\descriptionlabel[1]{%
         \hbox to 5.5em{\emph{#1}\hfil}}\vspace{2ex}\noindent\textbf{\xmlel{vs:CatalogResource} Type Schema Documentation}
 
-\noindent{\small
-            A resource giving astronomical data in tabular form.
-         \par}
+\noindent{\small{}A resource giving astronomical data in tabular form.\par}
 
-\noindent{\small
-            While this includes classical astronomical catalogues,
+\noindent{\small{}While this includes classical astronomical catalogues,
             this resource is also appropriate for collections of observations
             or simulation results provided their metadata are available
-            in a sufficiently structured form (e.g., Obscore, SSAP, etc).
-         \par}
+            in a sufficiently structured form (e.g., Obscore, SSAP, etc).\par}
 
 \vspace{1ex}\noindent\textbf{\xmlel{vs:CatalogResource} Type Schema Definition}
 
@@ -935,14 +913,10 @@ a service only publishes a single resource, use the
 \begingroup\small\begin{bigdescription}\item[Element \xmlel{tableset}]
 \begin{description}
 \item[Type] composite: \xmlel{vs:TableSet}
-\item[Meaning]
-                       A description of the tables that are accessible
+\item[Meaning] A description of the tables that are accessible
                        through this service.
-
 \item[Occurrence] optional
-\item[Comment]
-                     	Each schema name must be unique within a tableset.
-
+\item[Comment] Each schema name must be unique within a tableset.
 
 \end{description}
 
@@ -1094,11 +1068,9 @@ intervals on that level.
         \renewcommand*\descriptionlabel[1]{%
         \hbox to 5.5em{\emph{#1}\hfil}}\vspace{2ex}\noindent\textbf{\xmlel{vs:Coverage} Type Schema Documentation}
 
-\noindent{\small
-           A description of how a resource's contents or behavior maps
+\noindent{\small{}A description of how a resource's contents or behavior maps
            to the sky, to time, and to frequency space, including
-           coverage and resolution.
-         \par}
+           coverage and resolution.\par}
 
 \vspace{1ex}\noindent\textbf{\xmlel{vs:Coverage} Type Schema Definition}
 
@@ -1122,24 +1094,19 @@ intervals on that level.
 \vspace{0.5ex}\noindent\textbf{\xmlel{vs:Coverage} Metadata Elements}
 
 \begingroup\small\begin{bigdescription}\item[Element \xmlel{stc:STCResourceProfile}]
-
-                 An STC 1.0 description of the location of the resource's
+An STC 1.0 description of the location of the resource's
                  data on the sky, in time, and in frequency space,
                  including resolution.   This is deprecated in favour
                  of the separate spatial, temporal, and spectral elements.
-
 
 This element is imported from another schema.  See
             there for details.\item[Element \xmlel{spatial}]
 \begin{description}
 \item[Type] a string with optional attributes
-\item[Meaning]
-                  An ASCII-serialized MOC defining the spatial coverage
+\item[Meaning] An ASCII-serialized MOC defining the spatial coverage
                   of the resource.
-
 \item[Occurrence] optional
-\item[Comment]
-                  The MOC is to be understood in the ICRS reference frame
+\item[Comment] The MOC is to be understood in the ICRS reference frame
                   unless a frame attribute is given.
                   Resources should give the coverage at least to order 6
                   (a resolution of about one degree).  The order should be
@@ -1147,19 +1114,15 @@ This element is imported from another schema.  See
                   dozens of kB.  If desired, a more precise MOC can be provided
                   on a dedicated endpoint declared in the footprint element.
 
-
 \end{description}
 \item[Element \xmlel{temporal}]
 \begin{description}
 \item[Type] string of the form: \emph{[+-]?([0-9]+$\backslash$.?[0-9]*|$\backslash$.[0-9]+)([eE][+-]?[0-9]+)? [+-]?([0-9]+$\backslash$.?[0-9]*|$\backslash$.[0-9]+)([eE][+-]?[0-9]+)?}
-\item[Meaning]
-                  A pair of lower, upper limits of a time interval
+\item[Meaning] A pair of lower, upper limits of a time interval
                   for which the resource offers data.
-
 \item[Occurrence] optional; multiple occurrences allowed.
 
-\item[Comment]
-                  This is written as for VOTable tabledata (i.e.,
+\item[Comment] This is written as for VOTable tabledata (i.e.,
                   whitespace-separated C-style floating point literals), as
                   in “47847.2 51370.2”.
                   The limits must be given as MJD.  While they
@@ -1167,41 +1130,31 @@ This element is imported from another schema.  See
                   in TDB for the solar system barycenter.  The total coverage
                   of the resource is the union of all such intervals.
 
-
 \end{description}
 \item[Element \xmlel{spectral}]
 \begin{description}
 \item[Type] string of the form: \emph{[+-]?([0-9]+$\backslash$.?[0-9]*|$\backslash$.[0-9]+)([eE][+-]?[0-9]+)? [+-]?([0-9]+$\backslash$.?[0-9]*|$\backslash$.[0-9]+)([eE][+-]?[0-9]+)?}
-\item[Meaning]
-                  A pair of lower, upper limits of a spectral interval
+\item[Meaning] A pair of lower, upper limits of a spectral interval
                   for which the resource offers data.
-
 \item[Occurrence] optional; multiple occurrences allowed.
 
-\item[Comment]
-                  This is written as for VOTable tabledata (i.e.,
+\item[Comment] This is written as for VOTable tabledata (i.e.,
                   whitespace-separated C-style floating point literals).
                   The limits must be given in Joules of particle
                   energies.  While the limits are not intended
                   to be precise, they are to be understood for the
                   solar system barycenter.
-
-\item[Comment]
-                  For instance, the Johnson V waveband (480 .. 730 nm)
+\item[Comment] For instance, the Johnson V waveband (480 .. 730 nm)
                   would be specified as “2.72e-19 4.14e-19”
-
 
 \end{description}
 \item[Element \xmlel{footprint}]
 \begin{description}
 \item[Type] a URI with optional attributes
-\item[Meaning]
-                  A reference to a footprint service for retrieving
+\item[Meaning] A reference to a footprint service for retrieving
                   precise and up-to-date description of coverage.
-
 \item[Occurrence] optional
-\item[Comment]
-                  The ivo-id attribute here refers to the standard in which
+\item[Comment] The ivo-id attribute here refers to the standard in which
                   the footprint is given.  The only value defined by
                   VODataService at this point is ivo://ivoa.net/std/moc,
                   which indicates that retrieving the footprint URL will return
@@ -1210,46 +1163,37 @@ This element is imported from another schema.  See
                   function in VODataService 1.1.  The current meaning is what
                   implementors actually adopted.
 
-
 \end{description}
 \item[Element \xmlel{waveband}]
 \begin{description}
 \item[Type] string: \xmlel{xs:token}
-\item[Meaning]
-                  A name of a messenger that the resource is relevant for
+\item[Meaning] A name of a messenger that the resource is relevant for
                   (e.g., was used in the measurements).  Terms must
                   be taken from the vocabulary at
                   \url{http://www.ivoa.net/rdf/messenger}.
-
 \item[Occurrence] optional; multiple occurrences allowed.
-\item[Comment]
-                  It is a bit unfortunate that the element is still called
+\item[Comment] It is a bit unfortunate that the element is still called
                   waveband when it is now also covers non-electromagnetic
                   messengers.  It was deemed that this slight notional
                   sloppiness is preferable to introducing new and
                   deprecating old elements.
 
-
 \end{description}
 \item[Element \xmlel{regionOfRegard}]
 \begin{description}
 \item[Type] floating-point number: \xmlel{xs:float}
-\item[Meaning]
-                  A single numeric value representing the angle, given
+\item[Meaning] A single numeric value representing the angle, given
                   in decimal degrees, by which a positional query
                   against this resource should be “blurred” in order
                   to get an appropriate match.
-
 \item[Occurrence] optional
-\item[Comment]
-                  In the case of image repositories, it might refer to
+\item[Comment] In the case of image repositories, it might refer to
                   a typical field-of-view size, or the primary beam
                   size for radio aperture synthesis data.  In the case
                   of object catalogues RoR should normally be the
                   largest of the typical size of the objects, the
                   astrometric errors in the positions, or the
                   resolution of the data.
-
 
 \end{description}
 
@@ -1274,11 +1218,9 @@ defined here.
         \renewcommand*\descriptionlabel[1]{%
         \hbox to 5.5em{\emph{#1}\hfil}}\vspace{2ex}\noindent\textbf{\xmlel{vs:SpatialCoverage} Type Schema Documentation}
 
-\noindent{\small
-            A coverage on a sphere.  By default, this refers to the
+\noindent{\small{}A coverage on a sphere.  By default, this refers to the
             celestial sphere in the ICRS frame.  Non-celestial frames
-            are indicated by non-NULL values of the frame attribute.
-         \par}
+            are indicated by non-NULL values of the frame attribute.\par}
 
 \vspace{1ex}\noindent\textbf{\xmlel{vs:SpatialCoverage} Type Schema Definition}
 
@@ -1298,18 +1240,14 @@ defined here.
 \item[frame]
 \begin{description}
 \item[Type] string: \xmlel{xs:token}
-\item[Meaning]
-                     When present, the MOC is written in a non-celestial (e.g.,
+\item[Meaning] When present, the MOC is written in a non-celestial (e.g.,
                      planetary) frame.  Note that for celestial coverages,
                      ICRS must be used.
-
 \item[Occurrence] optional
-\item[Comment]
-                     VODataService 1.2 does not prescribe a vocabulary for
+\item[Comment] VODataService 1.2 does not prescribe a vocabulary for
                      what values are allowed here.  As
                      long as no such vocabulary is agreed upon, the frame
                      attribute should not be set.
-
 \end{description}
 
 
@@ -1332,17 +1270,13 @@ follows:
         \renewcommand*\descriptionlabel[1]{%
         \hbox to 5.5em{\emph{#1}\hfil}}\vspace{2ex}\noindent\textbf{\xmlel{vs:FloatInterval} Type Schema Documentation}
 
-\noindent{\small
-            An interval of floating point numbers.
-         \par}
+\noindent{\small{}An interval of floating point numbers.\par}
 
-\noindent{\small
-            This uses VOTable TABLEDATA serialisation, i.e., simply
+\noindent{\small{}This uses VOTable TABLEDATA serialisation, i.e., simply
             a pair of XSD floating point numbers separated by whitespace;
             note that software utilising non-XSD aware parsers has to
             perform whitespace normalisation itself here (in particular,
-            for the internal whitespace).
-         \par}
+            for the internal whitespace).\par}
 
 \vspace{1ex}\noindent\textbf{\xmlel{vs:FloatInterval} Type Schema Definition}
 
@@ -1364,11 +1298,9 @@ follows:
         \renewcommand*\descriptionlabel[1]{%
         \hbox to 5.5em{\emph{#1}\hfil}}\vspace{2ex}\noindent\textbf{\xmlel{vs:ServiceReference} Type Schema Documentation}
 
-\noindent{\small
-           The service URL for a potentially registered service.  That is,
+\noindent{\small{}The service URL for a potentially registered service.  That is,
            if an IVOA identifier is also provided, then the service is
-           described in a registry.
-         \par}
+           described in a registry.\par}
 
 \vspace{1ex}\noindent\textbf{\xmlel{vs:ServiceReference} Type Schema Definition}
 
@@ -1388,10 +1320,8 @@ follows:
 \item[ivo-id]
 \begin{description}
 \item[Type] an IVOA Identifier URI: vr:IdentifierURI
-\item[Meaning]
-                   The URI form of the IVOA identifier for the service
+\item[Meaning] The URI form of the IVOA identifier for the service
                    describing the capability refered to by this element.
-
 \item[Occurrence] optional
 \end{description}
 
@@ -1424,9 +1354,7 @@ tables.
         \renewcommand*\descriptionlabel[1]{%
         \hbox to 5.5em{\emph{#1}\hfil}}\vspace{2ex}\noindent\textbf{\xmlel{vs:TableSet} Type Schema Documentation}
 
-\noindent{\small
-           The set of tables hosted by a resource.
-         \par}
+\noindent{\small{}The set of tables hosted by a resource.\par}
 
 \vspace{1ex}\noindent\textbf{\xmlel{vs:TableSet} Type Schema Definition}
 
@@ -1450,24 +1378,18 @@ tables.
 \begingroup\small\begin{bigdescription}\item[Element \xmlel{schema}]
 \begin{description}
 \item[Type] composite: \xmlel{vs:TableSchema}
-\item[Meaning]
-                A named description of a group of logically related tables.
-
+\item[Meaning] A named description of a group of logically related tables.
 \item[Occurrence] required; multiple occurrences allowed.
-\item[Comment]
-                The name given by the “name” child element must
+\item[Comment] The name given by the “name” child element must
                 be unique within this TableSet instance.  If there is
                 only one schema in this set and/or there is no locally
                 appropriate name to provide, the name can be set to
                 “default”.
-
-\item[Comment]
-                This aggregation does not need to map to an
+\item[Comment] This aggregation does not need to map to an
                 actual database, catalogue, or schema, though the
                 publisher may choose to aggregate along such
                 designations.  Particular service protocols may
                 require stricter patterns.
-
 
 \end{description}
 
@@ -1502,9 +1424,7 @@ TAP\_SCHEMA's \verb|schema_index|.
         \renewcommand*\descriptionlabel[1]{%
         \hbox to 5.5em{\emph{#1}\hfil}}\vspace{2ex}\noindent\textbf{\xmlel{vs:TableSchema} Type Schema Documentation}
 
-\noindent{\small
-           A detailed description of a logically related group of tables.
-         \par}
+\noindent{\small{}A detailed description of a logically related group of tables.\par}
 
 \vspace{1ex}\noindent\textbf{\xmlel{vs:TableSchema} Type Schema Definition}
 
@@ -1527,71 +1447,53 @@ TAP\_SCHEMA's \verb|schema_index|.
 \begingroup\small\begin{bigdescription}\item[Element \xmlel{name}]
 \begin{description}
 \item[Type] string: \xmlel{xs:token}
-\item[Meaning]
-               A name for the group of tables.
-
+\item[Meaning] A name for the group of tables.
 \item[Occurrence] required
-\item[Comment]
-               This is used to uniquely identify the group of tables among
+\item[Comment] This is used to uniquely identify the group of tables among
                several groups.  If no title is given, this
                name can be used for display purposes.
-
-\item[Comment]
-               If there is no appropriate logical name associated with
+\item[Comment] If there is no appropriate logical name associated with
                this group, the name should be explicitly set to
                “default”.
-
 
 \end{description}
 \item[Element \xmlel{title}]
 \begin{description}
 \item[Type] string: \xmlel{xs:token}
-\item[Meaning]
-                  A descriptive, human-interpretable name for the group of
+\item[Meaning] A descriptive, human-interpretable name for the group of
                   tables.
-
 \item[Occurrence] optional
-\item[Comment]
-                  This is used for display purposes.  There is no requirement
+\item[Comment] This is used for display purposes.  There is no requirement
                   regarding uniqueness.  It is useful when there are
                   multiple schemas in the context (e.g., within a
                   tableset; otherwise, the resource title could be
                   used instead).
 
-
 \end{description}
 \item[Element \xmlel{description}]
 \begin{description}
 \item[Type] string: \xmlel{xs:token}
-\item[Meaning]
-               A free text description of the group of tables that should
+\item[Meaning] A free text description of the group of tables that should
                explain in general how all of the tables in the group are
                related.
-
 \item[Occurrence] optional
 
 \end{description}
 \item[Element \xmlel{utype}]
 \begin{description}
 \item[Type] string: \xmlel{xs:token}
-\item[Meaning]
-                  An identifier for a concept in a data model that
+\item[Meaning] An identifier for a concept in a data model that
                   the data in this schema as a whole represent.
-
 \item[Occurrence] optional
-\item[Comment]
-                  The form of the utype string depends on the data
+\item[Comment] The form of the utype string depends on the data
                   model; common forms are sequences of dotted identifiers
                   (e.g., in SSA) or URIs (e.g., in RegTAP).
-
 
 \end{description}
 \item[Element \xmlel{table}]
 \begin{description}
 \item[Type] composite: \xmlel{vs:Table}
-\item[Meaning]
-               A description of one table.
-
+\item[Meaning] A description of one table.
 \item[Occurrence] optional; multiple occurrences allowed.
 
 \end{description}
@@ -1644,15 +1546,13 @@ implied by TAP\_SCHEMA's \verb|table_index|.
 \item[type]
 \begin{description}
 \item[Type] string: \xmlel{xs:string}
-\item[Meaning]
-               A name for the role this table plays.  Recognized
+\item[Meaning] A name for the role this table plays.  Recognized
                values include “output”, indicating this table is output
                from a query; “base\_table”, indicating a table
                whose records represent the main subjects of its
                schema; and “view”, indicating that the table represents
                a useful combination or subset of other tables.  Other
                values are allowed.
-
 \item[Occurrence] optional
 \end{description}
 
@@ -1666,90 +1566,68 @@ implied by TAP\_SCHEMA's \verb|table_index|.
 \begingroup\small\begin{bigdescription}\item[Element \xmlel{name}]
 \begin{description}
 \item[Type] string: \xmlel{xs:token}
-\item[Meaning]
-                  The fully qualified name of the table.  This name
+\item[Meaning] The fully qualified name of the table.  This name
                   should include all catalogue or schema prefixes
                   needed to sufficiently uniquely distinguish it in a
                   query.
-
 \item[Occurrence] required
-\item[Comment]
-                  In general, the format of the qualified name may
+\item[Comment] In general, the format of the qualified name may
                   depend on the context; however, when the
                   table is intended to be queryable via ADQL, then the
                   catalogue and schema qualifiers are delimited from the
                   table name with dots (.).
 
-
 \end{description}
 \item[Element \xmlel{title}]
 \begin{description}
 \item[Type] string: \xmlel{xs:token}
-\item[Meaning]
-                  A descriptive, human-interpretable name for the table.
-
+\item[Meaning] A descriptive, human-interpretable name for the table.
 \item[Occurrence] optional
-\item[Comment]
-                  This is used for display purposes.  There is no requirement
+\item[Comment] This is used for display purposes.  There is no requirement
                   regarding uniqueness.
-
 
 \end{description}
 \item[Element \xmlel{description}]
 \begin{description}
 \item[Type] string: \xmlel{xs:token}
-\item[Meaning]
-                  A free-text description of the table's contents
-
+\item[Meaning] A free-text description of the table's contents
 \item[Occurrence] optional
 
 \end{description}
 \item[Element \xmlel{utype}]
 \begin{description}
 \item[Type] string: \xmlel{xs:token}
-\item[Meaning]
-                  An identifier for a concept in a data model that
+\item[Meaning] An identifier for a concept in a data model that
                   the data in this table represent.
-
 \item[Occurrence] optional
-\item[Comment]
-                  The form of the utype string depends on the data
+\item[Comment] The form of the utype string depends on the data
                   model; common forms are sequences of dotted identifiers
                   (e.g., in SSA) or URIs (e.g., in RegTAP).
-
 
 \end{description}
 \item[Element \xmlel{nrows}]
 \begin{description}
 \item[Type] \xmlel{xs:nonNegativeInteger}
-\item[Meaning]
-                  The approximate size of the table in rows.
-
+\item[Meaning] The approximate size of the table in rows.
 \item[Occurrence] optional
-\item[Comment]
-                  This is not expected to be exact.  For instance, the
+\item[Comment] This is not expected to be exact.  For instance, the
                   estimates on table sizes databases keep for query
                   planning purposes are suitable for this field.
-
 
 \end{description}
 \item[Element \xmlel{column}]
 \begin{description}
 \item[Type] composite: \xmlel{vs:TableParam}
-\item[Meaning]
-                  A description of a table column.
-
+\item[Meaning] A description of a table column.
 \item[Occurrence] optional; multiple occurrences allowed.
 
 \end{description}
 \item[Element \xmlel{foreignKey}]
 \begin{description}
 \item[Type] composite: \xmlel{vs:ForeignKey}
-\item[Meaning]
-                  A description of a foreign keys, one or more columns
+\item[Meaning] A description of a foreign keys, one or more columns
                   from the current table that can be used to join with
                   another table.
-
 \item[Occurrence] optional; multiple occurrences allowed.
 
 \end{description}
@@ -1821,16 +1699,12 @@ set of columns in another table.
         \renewcommand*\descriptionlabel[1]{%
         \hbox to 5.5em{\emph{#1}\hfil}}\vspace{2ex}\noindent\textbf{\xmlel{vs:ForeignKey} Type Schema Documentation}
 
-\noindent{\small
-           A description of the mapping a foreign key -- a set of
-           columns from one table -- to columns in another table.
-         \par}
+\noindent{\small{}A description of the mapping a foreign key -- a set of
+           columns from one table -- to columns in another table.\par}
 
-\noindent{\small
-            When foreign keys are declared in this way, clients can expect
+\noindent{\small{}When foreign keys are declared in this way, clients can expect
             that joins constrained with the foreign keys are preformed
-            efficiently (e.g., using an index).
-         \par}
+            efficiently (e.g., using an index).\par}
 
 \vspace{1ex}\noindent\textbf{\xmlel{vs:ForeignKey} Type Schema Definition}
 
@@ -1851,48 +1725,38 @@ set of columns in another table.
 \begingroup\small\begin{bigdescription}\item[Element \xmlel{targetTable}]
 \begin{description}
 \item[Type] string: \xmlel{xs:token}
-\item[Meaning]
-               The fully qualified name (including catalogue and schema, as
+\item[Meaning] The fully qualified name (including catalogue and schema, as
                applicable) of the table that can be joined with the
                table containing this foreign key.
-
 \item[Occurrence] required
 
 \end{description}
 \item[Element \xmlel{fkColumn}]
 \begin{description}
 \item[Type] composite: \xmlel{vs:FKColumn}
-\item[Meaning]
-               A pair of column names, one from this table and one
+\item[Meaning] A pair of column names, one from this table and one
                from the target table that should be used to join the
                tables in a query.
-
 \item[Occurrence] required; multiple occurrences allowed.
 
 \end{description}
 \item[Element \xmlel{description}]
 \begin{description}
 \item[Type] string: \xmlel{xs:token}
-\item[Meaning]
-                  A free-text description of what this key points to
+\item[Meaning] A free-text description of what this key points to
                   and what the relationship means.
-
 \item[Occurrence] optional
 
 \end{description}
 \item[Element \xmlel{utype}]
 \begin{description}
 \item[Type] string: \xmlel{xs:token}
-\item[Meaning]
-                  An identifier for a concept in a data model that
+\item[Meaning] An identifier for a concept in a data model that
                   the association enabled by this key represents.
-
 \item[Occurrence] optional
-\item[Comment]
-                  The form of the utype string depends on the data
+\item[Comment] The form of the utype string depends on the data
                   model; common forms are sequences of dotted identifiers
                   (e.g., in SSA) or URIs (e.g., in RegTAP).
-
 
 \end{description}
 
@@ -1979,15 +1843,11 @@ containers.
         \renewcommand*\descriptionlabel[1]{%
         \hbox to 5.5em{\emph{#1}\hfil}}\vspace{2ex}\noindent\textbf{\xmlel{vs:ParamHTTP} Type Schema Documentation}
 
-\noindent{\small
-           A service invoked via an HTTP Query (either Get or Post)
-           with a set of arguments consisting of keyword name-value pairs.
-        \par}
+\noindent{\small{}A service invoked via an HTTP Query (either Get or Post)
+           with a set of arguments consisting of keyword name-value pairs.\par}
 
-\noindent{\small
-           Note that the URL for help with this service can be put into
-           the service/referenceURL element.
-        \par}
+\noindent{\small{}Note that the URL for help with this service can be put into
+           the service/referenceURL element.\par}
 
 \vspace{1ex}\noindent\textbf{\xmlel{vs:ParamHTTP} Type Schema Definition}
 
@@ -2013,9 +1873,7 @@ containers.
 \begingroup\small\begin{bigdescription}\item[Element \xmlel{queryType}]
 \begin{description}
 \item[Type] string with controlled vocabulary
-\item[Meaning]
-                       The type of HTTP request, either GET or POST.
-
+\item[Meaning] The type of HTTP request, either GET or POST.
 \item[Occurrence] optional; up to 2 occurrences allowed.
 
 \item[Terms]\hfil
@@ -2023,8 +1881,7 @@ containers.
 \item[GET]
 \item[POST]
 \end{longtermsdescription}
-\item[Comment]
-                       The service may indicate support for both GET
+\item[Comment] The service may indicate support for both GET
                        and POST by providing 2 queryType elements, one
                        with GET and one with POST.  Since the IVOA standard
                        DALI requires standard services to support both
@@ -2032,44 +1889,35 @@ containers.
                        useful in the description of standard DAL services
                        and does not need to be given for those.
 
-
 \end{description}
 \item[Element \xmlel{resultType}]
 \begin{description}
 \item[Type] string: \xmlel{xs:token}
-\item[Meaning]
-                       The MIME media type of a document returned in
+\item[Meaning] The MIME media type of a document returned in
                        the HTTP response.
-
 \item[Occurrence] optional
 
 \end{description}
 \item[Element \xmlel{param}]
 \begin{description}
 \item[Type] composite: \xmlel{vs:InputParam}
-\item[Meaning]
-                       A description of a input parameter that can be
+\item[Meaning] A description of a input parameter that can be
                        provided as a name=value argument to the service.
-
 \item[Occurrence] optional; multiple occurrences allowed.
 
 \end{description}
 \item[Element \xmlel{testQuery}]
 \begin{description}
 \item[Type] string: \xmlel{xs:string}
-\item[Meaning]
-                       An ampersand-delimited list of arguments that
+\item[Meaning] An ampersand-delimited list of arguments that
                        can be used to test this service interface;
                        when provided as the input to this interface,
                        it will produce a legal, non-null response.
-
 \item[Occurrence] optional
-\item[Comment]
-                       When the interface supports GET, then the full
+\item[Comment] When the interface supports GET, then the full
                        query URL is formed by the concatenation of the
                        base URL (given by the accessURL) and the value
                        given by this testQuery element.
-
 
 \end{description}
 
@@ -2165,16 +2013,12 @@ metadata except the data type.
         \renewcommand*\descriptionlabel[1]{%
         \hbox to 5.5em{\emph{#1}\hfil}}\vspace{2ex}\noindent\textbf{\xmlel{vs:BaseParam} Type Schema Documentation}
 
-\noindent{\small
-            A description of a parameter that places no restriction on
-            the parameter's data type.
-         \par}
+\noindent{\small{}A description of a parameter that places no restriction on
+            the parameter's data type.\par}
 
-\noindent{\small
-            As the parameter's data type is usually important, schemas
+\noindent{\small{}As the parameter's data type is usually important, schemas
             normally employ a sub-class of this type
-            rather than this type directly.
-         \par}
+            rather than this type directly.\par}
 
 \vspace{1ex}\noindent\textbf{\xmlel{vs:BaseParam} Type Schema Definition}
 
@@ -2197,70 +2041,53 @@ metadata except the data type.
 \begingroup\small\begin{bigdescription}\item[Element \xmlel{name}]
 \begin{description}
 \item[Type] string: \xmlel{xs:token}
-\item[Meaning]
-                  The name of the parameter or column.
-
+\item[Meaning] The name of the parameter or column.
 \item[Occurrence] optional
 
 \end{description}
 \item[Element \xmlel{description}]
 \begin{description}
 \item[Type] string: \xmlel{xs:token}
-\item[Meaning]
-                  A free-text description of a parameter's or column's
+\item[Meaning] A free-text description of a parameter's or column's
                   contents.
-
 \item[Occurrence] optional
 
 \end{description}
 \item[Element \xmlel{unit}]
 \begin{description}
 \item[Type] string: \xmlel{xs:token}
-\item[Meaning]
-                  The unit associated with the values in the parameter
+\item[Meaning] The unit associated with the values in the parameter
                   or column.
-
 \item[Occurrence] optional
 
 \end{description}
 \item[Element \xmlel{ucd}]
 \begin{description}
 \item[Type] string: \xmlel{xs:token}
-\item[Meaning]
-                  The name of a unified content descriptor that
+\item[Meaning] The name of a unified content descriptor that
                   describes the scientific content of the parameter.
-
 \item[Occurrence] optional
-\item[Comment]
-                  There are no requirements for compliance with any
+\item[Comment] There are no requirements for compliance with any
                   particular UCD standard.
-
 
 \end{description}
 \item[Element \xmlel{utype}]
 \begin{description}
 \item[Type] string: \xmlel{xs:token}
-\item[Meaning]
-                  An identifier for a concept in a data model that
+\item[Meaning] An identifier for a concept in a data model that
                   the data in this schema represent.
-
 \item[Occurrence] optional
-\item[Comment]
-                  The form of the utype string depends on the data
+\item[Comment] The form of the utype string depends on the data
                   model; common forms are sequences of dotted identifiers
                   (e.g., in SSA) or URIs (e.g., in RegTAP).
-
 
 \end{description}
 \item[Element \xmlel{stats}]
 \begin{description}
 \item[Type] composite: \xmlel{vs:Stats}
-\item[Meaning]
-                  Statistics of the distribution underlying this parameter.
-
+\item[Meaning] Statistics of the distribution underlying this parameter.
 \item[Occurrence] optional
-\item[Comment]
-                  What “underlying distribution” means depends on the
+\item[Comment] What “underlying distribution” means depends on the
                   semantics of the derived type.  For vs:TableParam-s, for
                   instance, it would be the distribution of the values in
                   the corresponding table columns.  With vs:InputParam-s
@@ -2269,7 +2096,6 @@ metadata except the data type.
                   column.  For more complex input parameters, the
                   distribution of an associated physical quantity might also
                   be appropriate.
-
 
 \end{description}
 
@@ -2301,19 +2127,15 @@ namespaces.
         \renewcommand*\descriptionlabel[1]{%
         \hbox to 5.5em{\emph{#1}\hfil}}\vspace{2ex}\noindent\textbf{\xmlel{vs:Stats} Type Schema Documentation}
 
-\noindent{\small
-         Characterization of a distribution underlying a parameter.
-         \par}
+\noindent{\small{}Characterization of a distribution underlying a parameter.\par}
 
-\noindent{\small
-         Quasicontinuous distributions are defined here by their minimum
+\noindent{\small{}Quasicontinuous distributions are defined here by their minimum
          and maximum values (which are useful in UI generation, for instance),
          and the more robust 3rd and 97th percentiles (a “2σ range”) as well
          as the median for indications on the rough shape of the distribution.
          The element also admits arbitrary non-namespace child elements
          to enable the communication of further, more refined statistics.
-         Discrete distributions can be characterized using option elements.
-         \par}
+         Discrete distributions can be characterized using option elements.\par}
 
 \vspace{1ex}\noindent\textbf{\xmlel{vs:Stats} Type Schema Definition}
 
@@ -2339,64 +2161,50 @@ namespaces.
 \begingroup\small\begin{bigdescription}\item[Element \xmlel{min}]
 \begin{description}
 \item[Type] floating-point number: \xmlel{xs:double}
-\item[Meaning]
-               The smallest value occurring in a distribution of numbers.
-
+\item[Meaning] The smallest value occurring in a distribution of numbers.
 \item[Occurrence] optional
 
 \end{description}
 \item[Element \xmlel{percentile03}]
 \begin{description}
 \item[Type] floating-point number: \xmlel{xs:double}
-\item[Meaning]
-               The 3rd percentile (“2σ”) in a distribution of numbers.
-
+\item[Meaning] The 3rd percentile (“2σ”) in a distribution of numbers.
 \item[Occurrence] optional
 
 \end{description}
 \item[Element \xmlel{median}]
 \begin{description}
 \item[Type] floating-point number: \xmlel{xs:double}
-\item[Meaning]
-               The 50th percentile in a distribution of numbers.
-
+\item[Meaning] The 50th percentile in a distribution of numbers.
 \item[Occurrence] optional
 
 \end{description}
 \item[Element \xmlel{percentile97}]
 \begin{description}
 \item[Type] floating-point number: \xmlel{xs:double}
-\item[Meaning]
-               The 97nd percentile (“2σ”) in a distribution of numbers.
-
+\item[Meaning] The 97nd percentile (“2σ”) in a distribution of numbers.
 \item[Occurrence] optional
 
 \end{description}
 \item[Element \xmlel{max}]
 \begin{description}
 \item[Type] floating-point number: \xmlel{xs:double}
-\item[Meaning]
-               The largest value occurring in a distribution of numbers.
-
+\item[Meaning] The largest value occurring in a distribution of numbers.
 \item[Occurrence] optional
 
 \end{description}
 \item[Element \xmlel{fillFactor}]
 \begin{description}
 \item[Type] floating-point number: \xmlel{xs:float}
-\item[Meaning]
-               The ratio of not-NULL values to the total number of entries
+\item[Meaning] The ratio of not-NULL values to the total number of entries
                in a table column representing the distribution (or similar).
-
 \item[Occurrence] optional
 
 \end{description}
 \item[Element \xmlel{option}]
 \begin{description}
 \item[Type] a string with optional attributes
-\item[Meaning]
-               An entry in a discrete distribution.
-
+\item[Meaning] An entry in a discrete distribution.
 \item[Occurrence] optional; multiple occurrences allowed.
 
 \end{description}
@@ -2418,12 +2226,9 @@ combination of a string and a relative frequency:
         \renewcommand*\descriptionlabel[1]{%
         \hbox to 5.5em{\emph{#1}\hfil}}\vspace{2ex}\noindent\textbf{\xmlel{vs:TokenWithFrequency} Type Schema Documentation}
 
-\noindent{\small
-         An element of a discrete distribution within vs:Stats.
-         \par}
+\noindent{\small{}An element of a discrete distribution within vs:Stats.\par}
 
-\noindent{\small
-         This is a pair of an xs:token – where values are not naturally
+\noindent{\small{}This is a pair of an xs:token – where values are not naturally
          strings, use DALI or XSD literals – and its relative frequency.  For
          table columns, this would be the number of occurrences divided
          by the number of rows in the table.  Note that this means that missing
@@ -2431,8 +2236,7 @@ combination of a string and a relative frequency:
          an empty value will mean NULL; these cannot be distinguished
          from empty strings.  It is not mandatory to give freq in option
          elements, which is convenient for InputParam-s or when statistics
-         on the distribution are not available.
-         \par}
+         on the distribution are not available.\par}
 
 \vspace{1ex}\noindent\textbf{\xmlel{vs:TokenWithFrequency} Type Schema Definition}
 
@@ -2452,11 +2256,9 @@ combination of a string and a relative frequency:
 \item[freq]
 \begin{description}
 \item[Type] floating-point number: \xmlel{xs:float}
-\item[Meaning]
-                  The relative frequency of this value, defined as
+\item[Meaning] The relative frequency of this value, defined as
                   the number of occurrences divided by the number
                   of rows.
-
 \item[Occurrence] optional
 \end{description}
 
@@ -2492,15 +2294,11 @@ derive from a common parent, \xmlel{vs:DataType}.
         \renewcommand*\descriptionlabel[1]{%
         \hbox to 5.5em{\emph{#1}\hfil}}\vspace{2ex}\noindent\textbf{\xmlel{vs:DataType} Type Schema Documentation}
 
-\noindent{\small
-            A type (in the computer language sense) associated with a
-            parameter with an arbitrary name
-         \par}
+\noindent{\small{}A type (in the computer language sense) associated with a
+            parameter with an arbitrary name\par}
 
-\noindent{\small
-            This XML type is used as a parent for defining data types
-            with a restricted set of names.
-         \par}
+\noindent{\small{}This XML type is used as a parent for defining data types
+            with a restricted set of names.\par}
 
 \vspace{1ex}\noindent\textbf{\xmlel{vs:DataType} Type Schema Definition}
 
@@ -2524,75 +2322,55 @@ derive from a common parent, \xmlel{vs:DataType}.
 \item[arraysize]
 \begin{description}
 \item[Type] string of the form: \emph{([0-9]+x)*[0-9]*[0-9*]}
-\item[Meaning]
-                     The shape of the array that constitutes the value.
-
+\item[Meaning] The shape of the array that constitutes the value.
 \item[Occurrence] optional
 
-\item[Comment]
-                     Leave arraysize empty for scalar values.  In version 1.1,
+\item[Comment] Leave arraysize empty for scalar values.  In version 1.1,
                      this defaulted to 1, which was intended to indicate
                      a scalar.  This is now deprecated; an arraysize of 1 should
                      be avoided now, the future interpretation, in accord with
                      VOTable, will be “array of size 1”.
-
 \end{description}
 \item[delim]
 \begin{description}
 \item[Type] string: \xmlel{xs:string}
-\item[Meaning]
-                     A string that is used to delimit elements of an array
+\item[Meaning] A string that is used to delimit elements of an array
                      value in InputParams.
-
 \item[Occurrence] optional
-\item[Comment]
-                     Unless specifically disallowed by the context,
+\item[Comment] Unless specifically disallowed by the context,
                      applications should allow optional spaces to
                      appear in an actual data value before and after
                      the delimiter (e.g., “1, 5” when delim=“,”).
-
-\item[Comment]
-                     This should not be used for VOTable types; there,
+\item[Comment] This should not be used for VOTable types; there,
                      VOTable (typcially TABLEDATA) conventions for writing
                      arrays are binding.
-
 \end{description}
 \item[extendedType]
 \begin{description}
 \item[Type] string: \xmlel{xs:string}
-\item[Meaning]
-                     The data value represented by this type can be
+\item[Meaning] The data value represented by this type can be
                      interpreted as of a custom type identified by
                      the value of this attribute.
-
 \item[Occurrence] optional
-\item[Comment]
-                     If an application does not recognize this
+\item[Comment] If an application does not recognize this
                      extendedType, it should attempt to handle the value
                      assuming the type given by the element's value.
                      string is a recommended default type.
-
-\item[Comment]
-                     This element may make use of the extendedSchema
+\item[Comment] This element may make use of the extendedSchema
                      attribute to refine the identification of the
                      type.  extendedTypes without an extendedSchema
                      mean VOTable xtypes as defined by DALI.
-
 \end{description}
 \item[extendedSchema]
 \begin{description}
 \item[Type] a URI: \xmlel{xs:anyURI}
-\item[Meaning]
-                     An identifier for the schema that the value given
+\item[Meaning] An identifier for the schema that the value given
                      by the extended attribute is drawn from.
-
 \item[Occurrence] optional
-\item[Comment]
-                     This attribute is normally ignored if the
+\item[Comment] This attribute is normally ignored if the
                      extendedType attribute is not present.  A missing
                      extendedSchema indicates that extendedType is a
                      VOTable xtype.
-
 \end{description}
 
 
@@ -2673,15 +2451,11 @@ in \xmlel{vs:SimpleDataType}:
         \renewcommand*\descriptionlabel[1]{%
         \hbox to 5.5em{\emph{#1}\hfil}}\vspace{2ex}\noindent\textbf{\xmlel{vs:SimpleDataType} Type Schema Documentation}
 
-\noindent{\small
-            A data type restricted to a small set of names which is
-            imprecise as to the format of the individual values.
-         \par}
+\noindent{\small{}A data type restricted to a small set of names which is
+            imprecise as to the format of the individual values.\par}
 
-\noindent{\small
-            This set is intended for describing simple input parameters to
-            a service or function.
-         \par}
+\noindent{\small{}This set is intended for describing simple input parameters to
+            a service or function.\par}
 
 \vspace{1ex}\noindent\textbf{\xmlel{vs:SimpleDataType} Type Schema Definition}
 
@@ -2772,15 +2546,11 @@ the standard governing the capability the interface is in (if any):
         \renewcommand*\descriptionlabel[1]{%
         \hbox to 5.5em{\emph{#1}\hfil}}\vspace{2ex}\noindent\textbf{\xmlel{vs:InputParam} Type Schema Documentation}
 
-\noindent{\small
-            A description of a service or function parameter having a
-            fixed data type.
-         \par}
+\noindent{\small{}A description of a service or function parameter having a
+            fixed data type.\par}
 
-\noindent{\small
-         	DALI-compliant services should use VOTableType here, others
-         	should use SimpleDataType.
-         \par}
+\noindent{\small{}DALI-compliant services should use VOTableType here, others
+         	should use SimpleDataType.\par}
 
 \vspace{1ex}\noindent\textbf{\xmlel{vs:InputParam} Type Schema Definition}
 
@@ -2804,40 +2574,30 @@ the standard governing the capability the interface is in (if any):
 \item[use]
 \begin{description}
 \item[Type] string with controlled vocabulary
-\item[Meaning]
-                     An indication of whether this parameter is
+\item[Meaning] An indication of whether this parameter is
                      required to be provided for the application
                      or service to work properly.
-
 \item[Occurrence] optional
 
 \item[Terms]\hfil
 \begin{longtermsdescription}
-\item[required]
-                  The parameter is required for the application or
+\item[required]The parameter is required for the application or
                   service to work properly.
-
-\item[optional]
-                  The parameter is optional but supported by the application or
+\item[optional]The parameter is optional but supported by the application or
                   service.
-
-\item[ignored]
-                  The parameter is not supported and thus is ignored by the
+\item[ignored]The parameter is not supported and thus is ignored by the
                   application or service.
-
 \end{longtermsdescription}
 \item[Default] optional
 \end{description}
 \item[std]
 \begin{description}
 \item[Type] boolean (true/false): xs:boolean
-\item[Meaning]
-                     If true, the meaning and behavior of this parameter is
+\item[Meaning] If true, the meaning and behavior of this parameter is
                      reserved and defined by a standard interface.  If
                      false, it represents an implementation-specific
                      parameter that effectively extends the behavior of the
                      service or application.
-
 \item[Occurrence] optional
 \item[Default] true
 \end{description}
@@ -2852,9 +2612,7 @@ the standard governing the capability the interface is in (if any):
 \begingroup\small\begin{bigdescription}\item[Element \xmlel{dataType}]
 \begin{description}
 \item[Type] a string with optional attributes
-\item[Meaning]
-                        A type of data contained in the parameter.
-
+\item[Meaning] A type of data contained in the parameter.
 \item[Occurrence] optional
 
 \end{description}
@@ -2901,9 +2659,7 @@ a table.
         \renewcommand*\descriptionlabel[1]{%
         \hbox to 5.5em{\emph{#1}\hfil}}\vspace{2ex}\noindent\textbf{\xmlel{vs:TableParam} Type Schema Documentation}
 
-\noindent{\small
-            A description of a table parameter having a fixed data type.
-         \par}
+\noindent{\small{}A description of a table parameter having a fixed data type.\par}
 
 \vspace{1ex}\noindent\textbf{\xmlel{vs:TableParam} Type Schema Definition}
 
@@ -2928,12 +2684,10 @@ a table.
 \item[std]
 \begin{description}
 \item[Type] boolean (true/false): xs:boolean
-\item[Meaning]
-                     If true, the meaning and use of this parameter is
+\item[Meaning] If true, the meaning and use of this parameter is
                      reserved and defined by a standard model.  If false,
                      it represents a parameter specific to the data described
                      If not provided, then the value is unknown.
-
 \item[Occurrence] optional
 \end{description}
 
@@ -2947,29 +2701,23 @@ a table.
 \begingroup\small\begin{bigdescription}\item[Element \xmlel{dataType}]
 \begin{description}
 \item[Type] \xmlel{vs:DataType} with optional attributes
-\item[Meaning]
-                        A type of data contained in the column
-
+\item[Meaning] A type of data contained in the column
 \item[Occurrence] optional
 
 \end{description}
 \item[Element \xmlel{flag}]
 \begin{description}
 \item[Type] string: \xmlel{xs:token}
-\item[Meaning]
-                        A keyword representing traits of the column.
+\item[Meaning] A keyword representing traits of the column.
                         Recognized values include “indexed”, “primary”, and
                         “nullable”.
-
 \item[Occurrence] optional; multiple occurrences allowed.
-\item[Comment]
-                     	While other values are allowed, the following semantics
+\item[Comment] While other values are allowed, the following semantics
                      	is defined by this specification: indexed – The column
                      	has an index on it for faster search against its values;
                      	primary – The values column in the column represent in
                      	total or in part a primary key for its table; nullable –
                      	the column may contain null or empty values.
-
 
 \end{description}
 
@@ -3052,9 +2800,7 @@ should only generate \xmlel{vs:VOTableType}s in \xmlel{tableset}s.
         \renewcommand*\descriptionlabel[1]{%
         \hbox to 5.5em{\emph{#1}\hfil}}\vspace{2ex}\noindent\textbf{\xmlel{vs:VOTableType} Type Schema Documentation}
 
-\noindent{\small
-            A data type supported explicitly by the VOTable format
-         \par}
+\noindent{\small{}A data type supported explicitly by the VOTable format\par}
 
 \vspace{1ex}\noindent\textbf{\xmlel{vs:VOTableType} Type Schema Definition}
 


### PR DESCRIPTION
Sorry for the whitespace noise; the current whitespace is what we want, and I don't want to change the bad whitespace in generated content because that's already tagged as the released WD.  I should really fix this in ivoatex...